### PR TITLE
Add GitHub Actions workflow for NuGet package publishing

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,69 @@
+name: Build & Publish NuGet
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build'
+        required: false
+
+env:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Determine version
+        id: version
+        run: |
+          # Read base version (major.minor) from csproj
+          BASE_VERSION=$(grep -oP '(?<=<Version>).*(?=</Version>)' src/Component.Serialization/Component.Serialization.csproj)
+          BUILD_NUMBER=${{ github.run_number }}
+
+          if [[ "${{ github.ref_name }}" == "master" ]]; then
+            # Master: 0.0.1
+            VERSION="${BASE_VERSION}.${BUILD_NUMBER}"
+          else
+            # Branch: 0.0.2-feature-Workflow
+            BRANCH="${{ github.ref_name }}"
+            BRANCH_SUFFIX=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9-]/-/g')
+            VERSION="${BASE_VERSION}.${BUILD_NUMBER}-${BRANCH_SUFFIX}"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore -p:PackageVersion=${{ steps.version.outputs.version }}
+
+      - name: Pack
+        if: github.event_name != 'pull_request'
+        run: dotnet pack --configuration Release --no-restore --no-build --output ./nupkgs -p:PackageVersion=${{ steps.version.outputs.version }}
+
+      - name: Publish to GitHub Packages
+        if: github.event_name != 'pull_request'
+        run: dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --skip-duplicate

--- a/src/Component.Serialization/Component.Serialization.csproj
+++ b/src/Component.Serialization/Component.Serialization.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
    <PropertyGroup>
-      <TargetFrameworks>net45; netstandard2.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0</TargetFrameworks>
       <PackageId>ChacBolay.Component.Serialization</PackageId>
-      <Version>1.0.0</Version>
+      <Version>0.0</Version>
       <CodeAnalysisRuleSet>..\..\ruleset.ruleset</CodeAnalysisRuleSet>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
    </PropertyGroup>


### PR DESCRIPTION
- Automatic build and publish to GitHub Packages on push to master
- PR validation (build only, no pack/publish)
- Manual trigger via workflow_dispatch for branch builds
- Version pattern: {major.minor}.{run_number}[-branch-name]
- Update csproj: set base version to 0.0, target netstandard2.0